### PR TITLE
Add a `tree-sitter` item to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,5 +17,17 @@
   },
   "devDependencies": {
     "tree-sitter-cli": "^0.15.2"
-  }
+  },
+  "tree-sitter": [
+    {
+      "scope": "source.powershell",
+      "file-types": [
+        ".ps1",
+        ".psd1",
+        ".psm1"
+      ],
+      "injection-regex": "(powershell|pwsh)",
+      "first-line-regex": "^#!.*\b(powershell|pwsh)\b.*$"
+    }
+  ]
 }


### PR DESCRIPTION
This should allow detecting powershell files from the tree-sitter CLI by shebang, file type, or injection specifier.

See the config at https://tree-sitter.github.io/tree-sitter/syntax-highlighting#language-detection